### PR TITLE
Update InfraDeploymentGuide.md to re-add github credentials section

### DIFF
--- a/dashboards/CCODashboard-Infra/InfraDeploymentGuide.md
+++ b/dashboards/CCODashboard-Infra/InfraDeploymentGuide.md
@@ -198,6 +198,13 @@ If the permissions and credentials are properly flushed it should ask you for cr
 
 ![credentials4](/install/images/Credentials4.png)
 
+### Credentials for <span>github.com</span> Web
+- Click on **Anonymous**.
+- Click on **Sign in**.
+- Click on **Connect**.
+
+![DocsCredentials](/install/images/DocsCredentials.png)
+
 ### Credentials for <span>graph.windows.net</span> API
 
 - Click on **Organizational Account**.


### PR DESCRIPTION
github credentials was dropped in the most recent installation instructions update... added that back.