### PR TITLE
Microsoft.Resourcehealth is not required

### DIFF
--- a/dashboards/CCODashboard-Infra/InfraDeploymentGuide.md
+++ b/dashboards/CCODashboard-Infra/InfraDeploymentGuide.md
@@ -100,14 +100,13 @@ API URLs by environment:
 
 Although some of the Resource Providers might be enabled by default, you need to make sure that at least the **Microsoft.Advisor** and the **Microsoft.Security** resource providers are registered across all the  subscriptions that you plan analyze using the Dashboard. 
 
-Registering these 3 Resource Providers has no cost or performance penalty on the subscription:
+Registering these 2 Resource Providers has no cost or performance penalty on the subscription:
 
 1. Click on **Subscriptions**.
 2. Click on the Subscription name you want to configure.
 3. Click on **Resource Providers**.
 4. Click on **Microsoft.Advisor** and **Register**.
-5. Click on **Microsoft.Resourcehealth** and **Register**.
-6. Click on **Microsoft.Security** and **Register**.
+5. Click on **Microsoft.Security** and **Register**.
 
 ![resource providers](/install/images/resourceproviders.png)
 


### PR DESCRIPTION
Currently Microsoft.Resourcehealth is not required. See #149 

> Currently this is not required.
> 
> In the first releases we're using resource health API calls, but it's not needed anymore because the same information can be extracted from other sources if something is not OK.