### PR TITLE
Changes for entities in tablestorage

### DIFF
--- a/ghmetrics/src/CCOInsights.GitHubMetrics/github/ghapimessages.cs
+++ b/ghmetrics/src/CCOInsights.GitHubMetrics/github/ghapimessages.cs
@@ -70,6 +70,8 @@ public record IssueInfo
     public string? CreatedAt { get; init; }
     public string? UpdatedAt { get; init; }
     public string? ClosedAt { get; set; }
+    public string? Assignee { get; init; }
+    public string? Milestone { get; init; }
 }
 
 public record ReleaseInfo

--- a/ghmetrics/src/CCOInsights.GitHubMetrics/github/ghapimessages.cs
+++ b/ghmetrics/src/CCOInsights.GitHubMetrics/github/ghapimessages.cs
@@ -3,10 +3,9 @@
 public record GHExtractionResult
 {
     public RepoInfo? RepositoryInfo { get; set; }
-    public List<string> Forks { get; } = new();
-    public List<string> SecondaryForks { get; } = new();
-    public int? ClonesCount { get; set; }
-    public int? ViewsCount { get; set; }
+    public List<ForksInfo> Forks { get; } = new();
+    public List<ClonesInfo> Clones { get; set; } = new();
+    public List<ViewsInfo> Views { get; set; } = new();
     public List<PullRequestDetails> OpenPullRequests { get; } = new();
     public List<PullRequestDetails> ClosedPullRequests { get; } = new();
     public List<StargazerInfo> Stargazers { get; } = new();
@@ -44,6 +43,22 @@ public record PullRequestDetails
     public string? ClosedAt { get; set; }
 }
 
+public record ViewsInfo
+{
+    public string Id { get; init; }
+    public string Date { get; init; }
+    public int? Count { get; init; }
+    public int? Uniques { get; init; }
+}
+
+public record ClonesInfo
+{
+    public string Id { get; init; }
+    public string Date { get; init; }
+    public int? Count { get; init; }
+    public int? Uniques { get; init; }
+}
+
 public record StargazerInfo
 {
     public string? Login { get; init; }
@@ -72,6 +87,14 @@ public record IssueInfo
     public string? ClosedAt { get; set; }
     public string? Assignee { get; init; }
     public string? Milestone { get; init; }
+}
+
+public record ForksInfo
+{
+    public string FullName { get; init; }
+    public long Id { get; init; }
+    public string Owner { get; init; }
+    public string CreatedAt { get; init; }
 }
 
 public record ReleaseInfo

--- a/ghmetrics/src/CCOInsights.GitHubMetrics/github/ghextractor.cs
+++ b/ghmetrics/src/CCOInsights.GitHubMetrics/github/ghextractor.cs
@@ -53,35 +53,69 @@ public class GhExtractor
         {
             foreach (var fork in forksArray)
             {
-                var forkFullName = fork.GetProperty("full_name").GetString();
-                result.Forks.Add(forkFullName);
+                var forkInfo = new ForksInfo
+                {
+                    Id = fork.GetProperty("id").GetInt32(),
+                    FullName = fork.GetProperty("full_name").GetString(),
+                    Owner = fork.GetProperty("owner").GetProperty("login").GetString(),
+                    CreatedAt = fork.GetProperty("created_at").GetString()
+                };
+                result.Forks.Add(forkInfo);
 
-                var subForks = await GetJsonArrayAsync(_httpClient, $"https://api.github.com/repos/{forkFullName}/forks");
+                var subForks = await GetJsonArrayAsync(_httpClient, $"https://api.github.com/repos/{forkInfo.FullName}/forks");
                 if (subForks != null && subForks.Any())
                 {
                     foreach (var sf in subForks)
                     {
-                        var subForkUrl = sf.GetProperty("html_url").GetString();
-                        result.SecondaryForks.Add(subForkUrl);
+                        var subFork = new ForksInfo
+                        {
+                            Id = fork.GetProperty("id").GetInt32(),
+                            FullName = fork.GetProperty("full_name").GetString(),
+                            Owner = fork.GetProperty("owner").GetProperty("login").GetString(),
+                            CreatedAt = fork.GetProperty("created_at").GetString()
+                        };
+                        result.Forks.Add(subFork);
                     }
                 }
             }
         }
 
         // Traffic clones
-        var clones = await GetJsonAsync(_httpClient, $"https://api.github.com/repos/{_owner}/{_repo}/traffic/clones");
-        if (clones != null)
-        {
-            result.ClonesCount = clones.Value.GetProperty("count").GetInt32();
+        var clones = await GetJsonAsync(_httpClient, $"https://api.github.com/repos/{_owner}/{_repo}/traffic/clones?per_page=100");
+        if (clones != null) { 
+
+            var clonesArray = clones.Value.GetProperty("clones").EnumerateArray().ToArray();
+            foreach (var clone in clonesArray)
+            {
+                var cloneInfo = new ClonesInfo
+                {
+                    Id = clone.GetProperty("timestamp").GetString()?.Split(' ')[0].Replace("/", ""),
+                    Date = clone.GetProperty("timestamp").GetString(),
+                    Uniques = clone.GetProperty("uniques").GetInt32(),
+                    Count = clone.GetProperty("count").GetInt32()
+                };
+                result.Clones.Add(cloneInfo);
+            }
         }
 
         // Traffic views
-        var views = await GetJsonAsync(_httpClient, $"https://api.github.com/repos/{_owner}/{_repo}/traffic/views");
+        var views = await GetJsonAsync(_httpClient, $"https://api.github.com/repos/{_owner}/{_repo}/traffic/views?per_page=100");
         if (views != null)
         {
-            result.ViewsCount = views.Value.GetProperty("count").GetInt32();
+            var viewsArray = views.Value.GetProperty("views").EnumerateArray().ToArray();
+            foreach (var view in viewsArray)
+            {
+                var viewsInfo = new ViewsInfo
+                {
+                    Id = view.GetProperty("timestamp").GetString()?.Split(' ')[0].Replace("/", ""),
+                    Date = view.GetProperty("timestamp").GetString(),
+                    Uniques = view.GetProperty("uniques").GetInt32(),
+                    Count = view.GetProperty("count").GetInt32()
+                };
+                result.Views.Add(viewsInfo);
+            }
         }
-
+        
         // Pull Requests (open)
         var openPrs = await GetJsonArrayAsync(_httpClient, $"https://api.github.com/repos/{_owner}/{_repo}/pulls?state=open");
         if (openPrs != null)
@@ -153,7 +187,9 @@ public class GhExtractor
                         State = issue.GetProperty("state").GetString(),
                         CreatedAt = issue.GetProperty("created_at").GetString(),
                         UpdatedAt = issue.GetProperty("updated_at").GetString(),
-                        Assignee = issue.GetProperty("assignee").GetString() ?? string.Empty,
+                        Assignee = issue.GetProperty("assignee").ValueKind != JsonValueKind.Null
+                        ? issue.GetProperty("assignee").GetProperty("login").GetString() ?? string.Empty
+                        : string.Empty,
                     };
                     if (issue.TryGetProperty("closed_at", out var closedAt) && closedAt.ValueKind != JsonValueKind.Null)
                     {

--- a/ghmetrics/src/CCOInsights.GitHubMetrics/github/ghextractor.cs
+++ b/ghmetrics/src/CCOInsights.GitHubMetrics/github/ghextractor.cs
@@ -137,13 +137,13 @@ public class GhExtractor
         }
 
         // Issues (excluding PRs)
-        var issues = await GetJsonArrayAsync(_httpClient, $"https://api.github.com/repos/{_owner}/{_owner}/issues?state=all");
+        var issues = await GetJsonArrayAsync(_httpClient, $"https://api.github.com/repos/{_owner}/{_repo}/issues?state=all");
         if (issues != null)
         {
             foreach (var issue in issues)
             {
-                if (!issue.TryGetProperty("pull_request", out _))
-                {
+                //if (!issue.TryGetProperty("pull_request", out _))
+                //{
                     var issueInfo = new IssueInfo
                     {
                         Id = issue.GetProperty("id").GetInt64(),
@@ -152,14 +152,15 @@ public class GhExtractor
                         User = issue.GetProperty("user").GetProperty("login").GetString(),
                         State = issue.GetProperty("state").GetString(),
                         CreatedAt = issue.GetProperty("created_at").GetString(),
-                        UpdatedAt = issue.GetProperty("updated_at").GetString()
+                        UpdatedAt = issue.GetProperty("updated_at").GetString(),
+                        Assignee = issue.GetProperty("assignee").GetString() ?? string.Empty,
                     };
                     if (issue.TryGetProperty("closed_at", out var closedAt) && closedAt.ValueKind != JsonValueKind.Null)
                     {
                         issueInfo.ClosedAt = closedAt.GetString();
                     }
                     result.Issues.Add(issueInfo);
-                }
+                //}
             }
         }
 

--- a/ghmetrics/src/CCOInsights.GitHubMetrics/storage/Exporter.cs
+++ b/ghmetrics/src/CCOInsights.GitHubMetrics/storage/Exporter.cs
@@ -29,8 +29,6 @@ namespace CCOInsights.GithubMetrics.exports
                 Forks = data.RepositoryInfo.ForksCount,
                 Stargazers = data.RepositoryInfo.StarsCount,
                 Watchers = data.RepositoryInfo.WatchersCount,
-                Clones = data.ClonesCount,
-                Views = data.ViewsCount,
                 CreatedAt = data.RepositoryInfo.CreatedAt,
             };
 
@@ -69,6 +67,53 @@ namespace CCOInsights.GithubMetrics.exports
                 };
                 await tableClient.UpsertEntityAsync(starEntity);
             }
+            //Forks
+            tableClient = _tableServiceClient.GetTableClient("Forks");
+            await tableClient.CreateIfNotExistsAsync();
+            foreach (var fork in data.Forks)
+            {
+                var forkEntity = new ForkEntity
+                {
+                    RowKey = fork.Id.ToString(),
+                    FullName = fork.FullName,
+                    Owner = fork.Owner,
+                    CreatedAt = fork.CreatedAt,
+                    Id = fork.Id.ToString(),
+                };
+                await tableClient.UpsertEntityAsync(forkEntity);
+            }
+            //Clones
+            tableClient = _tableServiceClient.GetTableClient("Clones");
+            await tableClient.CreateIfNotExistsAsync();
+            foreach (var clone in data.Clones)
+            {
+                var cloneEntity = new CloneEntity
+                {
+                    RowKey = Guid.NewGuid().ToString(),
+                    Id = clone.Id,
+                    Date = clone.Date,
+                    Count = clone.Count ?? 0,
+                    Uniques = clone.Uniques ?? 0
+                };
+                await tableClient.UpsertEntityAsync(cloneEntity);
+            }
+
+            //Clones
+            tableClient = _tableServiceClient.GetTableClient("Views");
+            await tableClient.CreateIfNotExistsAsync();
+            foreach (var view in data.Views)
+            {
+                var viewEntity = new ViewEntity
+                {
+                    RowKey = Guid.NewGuid().ToString(),
+                    Id = view.Id,
+                    Date = view.Date,
+                    Count = view.Count ?? 0,
+                    Uniques = view.Uniques ?? 0
+                };
+                await tableClient.UpsertEntityAsync(viewEntity);
+            }
+
 
             // Contributors
             tableClient = _tableServiceClient.GetTableClient("Contributors");
@@ -95,7 +140,7 @@ namespace CCOInsights.GithubMetrics.exports
                     RowKey = issue.Id.ToString(),
                     Id = issue.Id.ToString(),
                     PartitionKey = "Issues",
-                    Assignee = issue.Assignee,
+                    Assignee = issue.Assignee ?? string.Empty,
                     Title = issue.Title,
                     User = issue.User,
                     State = issue.State,

--- a/ghmetrics/src/CCOInsights.GitHubMetrics/storage/Exporter.cs
+++ b/ghmetrics/src/CCOInsights.GitHubMetrics/storage/Exporter.cs
@@ -15,25 +15,30 @@ namespace CCOInsights.GithubMetrics.exports
         public async Task UploadGhDataAsync(
             GHExtractionResult data)
         {
-            var tableClient = _tableServiceClient.GetTableClient("REPODATA");
+            var tableClient = _tableServiceClient.GetTableClient("Repository");
             await tableClient.CreateIfNotExistsAsync();
-            var repoEntity = new GhDataTableEntity
+            var repoEntity = new RepositoryEntity
             {
                 PartitionKey= "RepositoryInfo",
                 RowKey = data.RepositoryInfo.Id.ToString(),
-                RepoName = data.RepositoryInfo.Name,
+                Id = data.RepositoryInfo.Id.ToString(),
+                Name = data.RepositoryInfo.Name,
+                FullName = data.RepositoryInfo.FullName,
                 Owner = data.RepositoryInfo.Owner,
-                ForksCount = data.RepositoryInfo.ForksCount,
-                StarsCount = data.RepositoryInfo.StarsCount,
-                ClonesCount = data.ClonesCount,
-                ViewsCount = data.ViewsCount,
+                OpenIssues = data.RepositoryInfo.OpenIssuesCount,
+                Forks = data.RepositoryInfo.ForksCount,
+                Stargazers = data.RepositoryInfo.StarsCount,
+                Watchers = data.RepositoryInfo.WatchersCount,
+                Clones = data.ClonesCount,
+                Views = data.ViewsCount,
+                CreatedAt = data.RepositoryInfo.CreatedAt,
             };
 
             await tableClient.UpsertEntityAsync(repoEntity);
             
 
             // Open Pull Requests
-            tableClient = _tableServiceClient.GetTableClient("OPENPRS");
+            tableClient = _tableServiceClient.GetTableClient("OpenPRs");
             await tableClient.CreateIfNotExistsAsync();
             foreach (var pr in data.OpenPullRequests)
             {
@@ -42,7 +47,7 @@ namespace CCOInsights.GithubMetrics.exports
             }
 
             // Closed Pull Requests
-            tableClient = _tableServiceClient.GetTableClient("CLOSEDPRS");
+            tableClient = _tableServiceClient.GetTableClient("ClosedPRs");
             await tableClient.CreateIfNotExistsAsync();
             foreach (var pr in data.ClosedPullRequests)
             {
@@ -51,7 +56,7 @@ namespace CCOInsights.GithubMetrics.exports
             }
 
             // Stargazers
-            tableClient = _tableServiceClient.GetTableClient("STARGAZERS");
+            tableClient = _tableServiceClient.GetTableClient("Stargazers");
             await tableClient.CreateIfNotExistsAsync();
             foreach (var star in data.Stargazers)
             {
@@ -66,45 +71,51 @@ namespace CCOInsights.GithubMetrics.exports
             }
 
             // Contributors
-            tableClient = _tableServiceClient.GetTableClient("CONTRIBUTORS");
+            tableClient = _tableServiceClient.GetTableClient("Contributors");
             await tableClient.CreateIfNotExistsAsync();
             foreach (var contr in data.Contributors)
             {
                 var contrEntity = new ContributorEntity
                 {
                     RowKey = contr.Id.ToString(),
+                    Login = contr.Login,
+                    Id = contr.Id.ToString(),
                     AvatarUrl = contr.AvatarUrl
                 };
                 await tableClient.UpsertEntityAsync(contrEntity);
             }
 
             // Issues
-            tableClient = _tableServiceClient.GetTableClient("ISSUES");
+            tableClient = _tableServiceClient.GetTableClient("Issues");
             await tableClient.CreateIfNotExistsAsync();
             foreach (var issue in data.Issues)
             {
                 var issueEntity = new IssueEntity
                 {
                     RowKey = issue.Id.ToString(),
+                    Id = issue.Id.ToString(),
+                    PartitionKey = "Issues",
+                    Assignee = issue.Assignee,
                     Title = issue.Title,
                     User = issue.User,
                     State = issue.State,
                     CreatedAt = issue.CreatedAt,
                     UpdatedAt = issue.UpdatedAt,
-                    ClosedAt = issue.ClosedAt
+                    ClosedAt = issue.ClosedAt,
+                    Milestone = issue.Milestone
                 };
                 await tableClient.UpsertEntityAsync(issueEntity);
             }
 
             // Releases
-            tableClient = _tableServiceClient.GetTableClient("RELEASES");
+            tableClient = _tableServiceClient.GetTableClient("Releases");
             await tableClient.CreateIfNotExistsAsync();
             foreach (var release in data.Releases)
             {
                 var releaseEntity = new ReleaseEntity
                 {
                     RowKey = Guid.NewGuid().ToString(),
-                    PublishedAt = release.PublishedAt
+                    PublishedAt = release.PublishedAt,
                 };
                 await tableClient.UpsertEntityAsync(releaseEntity);
             }
@@ -115,16 +126,18 @@ namespace CCOInsights.GithubMetrics.exports
             return new PullRequestEntity
             {
                 PartitionKey = partitionKey,
+                Id = pr.Id.ToString(),
+                Number = pr.Number,
                 RowKey = pr.Id.ToString(),
                 Title = pr.Title,
                 User = pr.User,
                 State = pr.State,
-                CreatedAt = pr.CreatedAt,
+                CreatedDate = pr.CreatedAt,
                 Additions = pr.Additions,
                 Deletions = pr.Deletions,
                 ChangedFiles = pr.ChangedFiles,
-                ClosedAt = pr.ClosedAt,
-                MergedAt = pr.MergedAt
+                ClosedDate = pr.ClosedAt,
+                MergedDate = pr.MergedAt
             };
         }
     }

--- a/ghmetrics/src/CCOInsights.GitHubMetrics/storage/TableEntities.cs
+++ b/ghmetrics/src/CCOInsights.GitHubMetrics/storage/TableEntities.cs
@@ -4,19 +4,23 @@ using Azure.Data.Tables;
 
 namespace CCOInsights.GithubMetrics.exports
 {
-    public class GhDataTableEntity : ITableEntity
+    public class RepositoryEntity : ITableEntity
     {
         public string PartitionKey { get; set; } = default!;
         public string RowKey { get; set; } = default!;
         public DateTimeOffset? Timestamp { get; set; }
         public ETag ETag { get; set; }
-
-        public string? RepoName { get; set; }
+        public string Id { get; set; }
+        public string? FullName { get; set; }
+        public string? Name { get; set; }
         public string? Owner { get; set; }
-        public int? ForksCount { get; set; }
-        public int? StarsCount { get; set; }
-        public int? ClonesCount { get; set; }
-        public int? ViewsCount { get; set; }
+        public int? OpenIssues { get; set; }
+        public int? Forks { get; set; }
+        public int? Stargazers { get; set; }
+        public int? Watchers { get; set; }
+        public int? Clones { get; set; }
+        public int? Views { get; set; }
+        public string? CreatedAt { get; set; }
     }
 
     // Fork entity
@@ -42,15 +46,17 @@ namespace CCOInsights.GithubMetrics.exports
     {
         public string PartitionKey { get; set; } = default!;
         public string RowKey { get; set; } = default!;
+        public string Id { get; set; } 
         public string? Title { get; set; }
         public string? User { get; set; }
         public string? State { get; set; }
-        public string? CreatedAt { get; set; }
         public int Additions { get; set; }
         public int Deletions { get; set; }
         public int ChangedFiles { get; set; }
-        public string? ClosedAt { get; set; }
-        public string? MergedAt { get; set; }
+        public string CreatedDate { get; set; }
+        public int Number { get; set; }
+        public string ClosedDate { get; set; }
+        public string? MergedDate { get; set; }
         public DateTimeOffset? Timestamp { get; set; }
         public ETag ETag { get; set; }
     }
@@ -72,6 +78,8 @@ namespace CCOInsights.GithubMetrics.exports
     {
         public string PartitionKey { get; set; } = "Contributors";
         public string RowKey { get; set; } = default!;
+        public string? Login { get; set; }
+        public string Id { get; set; }
         public string? AvatarUrl { get; set; }
         public DateTimeOffset? Timestamp { get; set; }
         public ETag ETag { get; set; }
@@ -82,6 +90,10 @@ namespace CCOInsights.GithubMetrics.exports
     {
         public string PartitionKey { get; set; } = "Issues";
         public string RowKey { get; set; } = default!;
+        public string Assignee { get; set; }
+        public string? Id { get; set; }
+        public string? Number { get; set; }
+        public string? Milestone { get; set; }
         public string? Title { get; set; }
         public string? User { get; set; }
         public string? State { get; set; }

--- a/ghmetrics/src/CCOInsights.GitHubMetrics/storage/TableEntities.cs
+++ b/ghmetrics/src/CCOInsights.GitHubMetrics/storage/TableEntities.cs
@@ -28,18 +28,42 @@ namespace CCOInsights.GithubMetrics.exports
     {
         public string PartitionKey { get; set; } = "Forks";
         public string RowKey { get; set; } = default!;
+        public string Id { get; set; } = default!;
+        public string FullName { get; set; } = default!;
+        public string Owner { get; set; }
+        public string CreatedAt { get; set; } = default!;
         public DateTimeOffset? Timestamp { get; set; }
         public ETag ETag { get; set; }
     }
 
-    // Secondary fork entity
-    public class SecondaryForkEntity : ITableEntity
+    // Clone entity
+    public class CloneEntity : ITableEntity
     {
-        public string PartitionKey { get; set; } = "SecondaryForks";
+        public string PartitionKey { get; set; } = "Clones";
         public string RowKey { get; set; } = default!;
+        public string Id { get; set; } = default!;
+        public string Date { get; set; } = default!;
+        public int Count { get; set; } = default!;
+        public int Uniques { get; set; } = default!;
+
         public DateTimeOffset? Timestamp { get; set; }
         public ETag ETag { get; set; }
     }
+
+
+    // View entity
+    public class ViewEntity : ITableEntity
+    {
+        public string PartitionKey { get; set; } = "Views";
+        public string RowKey { get; set; } = default!;
+        public string Id { get; set; } = default!;
+        public string Date { get; set; } = default!;
+        public int Count { get; set; } = default!;
+        public int Uniques { get; set; } = default!;
+        public DateTimeOffset? Timestamp { get; set; }
+        public ETag ETag { get; set; }
+    }
+
 
     // Pull request entity
     public class PullRequestEntity : ITableEntity


### PR DESCRIPTION
This pull request introduces significant changes to the `ghmetrics` project, focusing on enhancing data extraction, storage, and entity definitions. Key updates include improvements to issue handling, renaming and restructuring of table entities, and the addition of new fields to better capture repository and contributor data.

### Enhancements to issue handling:
* Added `Assignee` and `Milestone` fields to the `IssueInfo` record to capture additional metadata about issues. (`ghmetrics/src/CCOInsights.GitHubMetrics/github/ghapimessages.cs`, [ghmetrics/src/CCOInsights.GitHubMetrics/github/ghapimessages.csR73-R74](diffhunk://#diff-c4fc10e4c1270a93d6ae75ec172b671a3ee88da4d760dbb664fd8056230b0e28R73-R74))
* Updated the `ExtractData` method to include the `Assignee` field when processing issues. (`ghmetrics/src/CCOInsights.GitHubMetrics/github/ghextractor.cs`, [ghmetrics/src/CCOInsights.GitHubMetrics/github/ghextractor.csL155-R163](diffhunk://#diff-1b270aab1c4115640110a5b9419c9414da69c15c9ccd38b9dda630b507fa74c7L155-R163))

### Updates to table entities:
* Renamed `GhDataTableEntity` to `RepositoryEntity` and added fields such as `FullName`, `OpenIssues`, `Watchers`, and `CreatedAt` to better represent repository data. (`ghmetrics/src/CCOInsights.GitHubMetrics/storage/TableEntities.cs`, [ghmetrics/src/CCOInsights.GitHubMetrics/storage/TableEntities.csL7-R23](diffhunk://#diff-99a68321e3ff336b2758fb13dde261bdb0ebca8bf5d97c61f90078878eda6b28L7-R23))
* Modified `PullRequestEntity` to include `Id`, `Number`, `CreatedDate`, `ClosedDate`, and `MergedDate` fields for more detailed pull request tracking. (`ghmetrics/src/CCOInsights.GitHubMetrics/storage/TableEntities.cs`, [ghmetrics/src/CCOInsights.GitHubMetrics/storage/TableEntities.csR49-R59](diffhunk://#diff-99a68321e3ff336b2758fb13dde261bdb0ebca8bf5d97c61f90078878eda6b28R49-R59))
* Enhanced `ContributorEntity` with `Login` and `Id` fields for better contributor identification. (`ghmetrics/src/CCOInsights.GitHubMetrics/storage/TableEntities.cs`, [ghmetrics/src/CCOInsights.GitHubMetrics/storage/TableEntities.csR81-R82](diffhunk://#diff-99a68321e3ff336b2758fb13dde261bdb0ebca8bf5d97c61f90078878eda6b28R81-R82))
* Expanded `IssueEntity` to include `Assignee`, `Id`, `Number`, and `Milestone` fields for enriched issue data storage. (`ghmetrics/src/CCOInsights.GitHubMetrics/storage/TableEntities.cs`, [ghmetrics/src/CCOInsights.GitHubMetrics/storage/TableEntities.csR93-R96](diffhunk://#diff-99a68321e3ff336b2758fb13dde261bdb0ebca8bf5d97c61f90078878eda6b28R93-R96))

### Adjustments to storage logic:
* Renamed table names for clarity and consistency (e.g., `REPODATA` to `Repository`, `OPENPRS` to `OpenPRs`, `ISSUES` to `Issues`, etc.). (`ghmetrics/src/CCOInsights.GitHubMetrics/storage/Exporter.cs`, [[1]](diffhunk://#diff-1de9b4c070993f96b2230f358f4fad6f46db942cbcc32d72ceb31d8229c2d20eL18-R41) [[2]](diffhunk://#diff-1de9b4c070993f96b2230f358f4fad6f46db942cbcc32d72ceb31d8229c2d20eL45-R50) [[3]](diffhunk://#diff-1de9b4c070993f96b2230f358f4fad6f46db942cbcc32d72ceb31d8229c2d20eL54-R59) [[4]](diffhunk://#diff-1de9b4c070993f96b2230f358f4fad6f46db942cbcc32d72ceb31d8229c2d20eL69-R118)
* Updated entity creation logic to align with new table entity definitions, ensuring proper mapping of fields. (`ghmetrics/src/CCOInsights.GitHubMetrics/storage/Exporter.cs`, [ghmetrics/src/CCOInsights.GitHubMetrics/storage/Exporter.csR129-R140](diffhunk://#diff-1de9b4c070993f96b2230f358f4fad6f46db942cbcc32d72ceb31d8229c2d20eR129-R140))

