### PR TITLE
Change GitHub API URL to fetch open pull requests

### DIFF
--- a/dashboards/GitHubDashboard-Contributors/src/GitHubContributions/Modules/Common/Common.psm1
+++ b/dashboards/GitHubDashboard-Contributors/src/GitHubContributions/Modules/Common/Common.psm1
@@ -175,7 +175,7 @@ Function Get-OpenPullRequests {
     $table = (Get-AzStorageTable –Name $partitionKey –Context $ctx).CloudTable
 
     Write-Host "Fetching open pull requests..."
-    $openPullRequestsBaseUrl = "https://api.github.com/repos/$($owner)/$($repository)/pulls?state=all&per_page=100"
+    $openPullRequestsBaseUrl = "https://api.github.com/repos/$($owner)/$($repository)/pulls?state=open&per_page=100"
     $header = @{authorization = "token $pat" }
     $page = 1
 


### PR DESCRIPTION
Fixed Get-OpenPullRequests API Call

# Change

The `Get-OpenPullRequests` Function in the module is getting all of the PRs from the repo instead of getting only the ones whose status is `open`.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update (Wiki)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I've tested the solution locally without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
